### PR TITLE
Add default value for VoiceMessage Recognition field check.

### DIFF
--- a/wechat_sdk/messages.py
+++ b/wechat_sdk/messages.py
@@ -100,7 +100,7 @@ class VoiceMessage(WechatMessage):
         try:
             self.media_id = message.pop('MediaId')
             self.format = message.pop('Format')
-            self.recognition = message.pop('Recognition')
+            self.recognition = message.pop('Recognition', '')
         except KeyError:
             raise ParseError()
         super(VoiceMessage, self).__init__(message)


### PR DESCRIPTION
If wechat didn't recognize any thing, they will send a VoiceMessage with empty Recognition field, currently this will raise a ParseError.
