### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,14 @@
 # !/usr/bin/env python
 
 from setuptools import setup, find_packages
+import codecs
 
 setup(
     name='wechat-sdk',
     version='0.6.3',
     keywords=('wechat', 'sdk', 'wechat sdk'),
     description=u'微信公众平台Python开发包',
-    long_description=open("README.rst").read(),
+    long_description=codecs.open("README.rst","r","utf-8").read(),
     license='BSD License',
 
     url='https://github.com/wechat-python-sdk/wechat-python-sdk',


### PR DESCRIPTION
处理安装时报“UnicodeDecodeError: 'gbk' codec can't decode byte 0xae in position 2: illegal multibyte sequence”的错误。