### PR TITLE
OSX EI Capitan Install with pip

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,10 @@ wechat-python-sdk 希望能帮你解决微信公众平台开发中的种种不�
 
     pip install wechat-sdk
 
+::
+
+    OSX EI Capitan: sudo pip install wechat-sdk --ignore-installed six
+
 也可以通过 easy_install 进行安装
 
 ::


### PR DESCRIPTION
osx ei capitan下 pip 安装时候 报错。
系统依赖py的包依赖six，导致无法修改
OSError: [Errno 1] Operation not permitted: '/tmp/pip-QrNkoK-uninstall/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python/six-1.4.1-py2.7.egg-info'
