### PR TITLE
[PR]线程安全改进和小Fix : )

### DIFF
--- a/wechat_sdk/basic.py
+++ b/wechat_sdk/basic.py
@@ -140,8 +140,6 @@ class WechatBasic(WechatBase):
         :param nonce: EncodingAESKey 用随机数
         :raises ParseError: 解析微信服务器数据错误, 数据不合法
         """
-        result = {}
-
         if isinstance(data, six.text_type):  # unicode to str(PY2), str to bytes(PY3)
             data = data.encode('utf-8')
 

--- a/wechat_sdk/basic.py
+++ b/wechat_sdk/basic.py
@@ -141,6 +141,7 @@ class WechatBasic(WechatBase):
         :raises ParseError: 解析微信服务器数据错误, 数据不合法
         """
         result = {}
+
         if isinstance(data, six.text_type):  # unicode to str(PY2), str to bytes(PY3)
             data = data.encode('utf-8')
 
@@ -164,8 +165,10 @@ class WechatBasic(WechatBase):
         result['type'] = result.pop('MsgType').lower()
 
         message_type = MESSAGE_TYPES.get(result['type'], UnknownMessage)
-        self.__message = message_type(result)
+        message = message_type(result)
+        self.__message = message
         self.__is_parse = True
+        return message
 
     @property
     def message(self):


### PR DESCRIPTION
Hi~
使用了一下你的SDK，感觉非常不错~
其中有一个小问题。
我希望能只初始化一个WechatBasic，然后用它来处理所有的请求（可以认为一段时间内conf之类的信息是不变的）。
但我发现，如果用同一个对象来parse不同的message，多线程的情况下，parse过程并不是线程安全的，可能会出现两个线程同时parse了一个数据，但是修改顺序不确定，导致对象的message返回不符合预期。

要保证线程安全，只能每次都初始化一个WechatBasic对象，我添加了基本的改进：），用来确保起码parse_data能得到想要的结果。

可能还需要做更多的工作才能做到线程安全，这个PR只是一个小小的改进：）
