### PR TITLE
设置 requests 的 timeout ，如果不设 timeout，requests 的默认行为会一直等待

### DIFF
--- a/wechat_sdk/basic.py
+++ b/wechat_sdk/basic.py
@@ -26,7 +26,8 @@ class WechatBasic(WechatBase):
     """
     def __init__(self, token=None, appid=None, appsecret=None, partnerid=None,
                  partnerkey=None, paysignkey=None, access_token=None, access_token_expires_at=None,
-                 jsapi_ticket=None, jsapi_ticket_expires_at=None, checkssl=False, conf=None):
+                 jsapi_ticket=None, jsapi_ticket_expires_at=None, checkssl=False, timeout=(20, 60),
+                 conf=None):
         """
         :param token: 微信 Token
         :param appid: App ID
@@ -756,11 +757,13 @@ class WechatBasic(WechatBase):
         :param ticket: 二维码 ticket 。可以通过 :func:`create_qrcode` 获取到
         :return: 返回的 Request 对象
         """
+        timeout = self.__conf.timeout if self.__conf is not None else (20, 60)
         return requests.get(
             url='https://mp.weixin.qq.com/cgi-bin/showqrcode',
             params={
                 'ticket': ticket
-            }
+            },
+            timeout=timeout
         )
 
     def set_template_industry(self, industry_id1, industry_id2):

--- a/wechat_sdk/core/conf.py
+++ b/wechat_sdk/core/conf.py
@@ -52,6 +52,7 @@ class WechatConf(object):
                        'paysignkey': 商户签名密钥 Key, 支付权限专用
 
                        'checkssl': 是否检查 SSL, 默认不检查 (False), 可避免 urllib3 的 InsecurePlatformWarning 警告
+                       'timeout': 设置 requests 的 timeout, 默认 (20, 60)
         :return:
         """
 
@@ -85,6 +86,12 @@ class WechatConf(object):
         self.__partnerid = kwargs.get('partnerid')
         self.__partnerkey = kwargs.get('partnerkey')
         self.__paysignkey = kwargs.get('paysignkey')
+
+        self.__timeout = kwargs.get('timeout', (20, 60))
+
+    @property
+    def timeout(self):
+        return self.__timeout
 
     @property
     def token(self):

--- a/wechat_sdk/lib/request.py
+++ b/wechat_sdk/lib/request.py
@@ -29,6 +29,7 @@ class WechatRequest(object):
         :return: 微信服务器响应的 JSON 数据
         """
         access_token = self.__conf.access_token if self.__conf is not None else access_token
+        timeout = self.__conf.timeout if self.__conf is not None else (20, 60)
         if "params" not in kwargs:
             kwargs["params"] = {
                 "access_token": access_token
@@ -45,6 +46,7 @@ class WechatRequest(object):
         r = requests.request(
             method=method,
             url=url,
+            timeout=timeout,
             **kwargs
         )
         r.raise_for_status()


### PR DESCRIPTION
http://docs.python-requests.org/en/master/user/advanced/#timeouts

Most requests to external servers should have a timeout attached, in case the server is not responding in a timely manner. By default, requests do not time out unless a timeout value is set explicitly. Without a timeout, your code may hang for minutes or more.

