### PR TITLE
修复 aes 加密填充的 bug

### DIFF
--- a/wechat_sdk/lib/crypto/base.py
+++ b/wechat_sdk/lib/crypto/base.py
@@ -28,8 +28,9 @@ class BaseCrypto(object):
         @param text: 需要加密的明文
         @return: 加密得到的字符串
         """
+        text = to_binary(text)
         # 16位随机字符串添加到明文开头
-        text = self.get_random_str() + struct.pack("I", socket.htonl(len(text))) + to_binary(text) + appid
+        text = self.get_random_str() + struct.pack("I", socket.htonl(len(text))) + text + appid
         # 使用自定义的填充方式对明文进行补位填充
         pkcs7 = PKCS7Encoder()
         text = pkcs7.encode(text)


### PR DESCRIPTION
回复消息中包含中文字符的时候会失败